### PR TITLE
V0.2.4 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,6 @@ This module currently does the following:
 - Adds the exp awarding system, and a thing that holds back the xp until the player clicks "level up", and auto-evolution (disabled by default in the module settings)
 - Adds perk prerequisite checking (string parsing) and auto-skill assignment if you can meet the prerequisite by increasing a skill (can be disabled in the settings)
 - Prompts the gm to add a token to an encounter if you add one mid-battle
+- Add settings that disable the automatic token shrinking (making the smallest automatic token a 1x1)
 - A categorized skill system. This is currently hidden from the options, as it's not ready for testing (switching back and forth causes issues)
 - Module compatibility for Item Piles

--- a/js/main.mjs
+++ b/js/main.mjs
@@ -7,6 +7,7 @@ import * as encounter from "./encounter-building.mjs";
 import * as exp from "./experience/index.mjs";
 import * as tokenDisplay from "./token-display.mjs";
 import * as tokenDrop from "./token-drop.mjs";
+import * as tokenSize from "./token-size.mjs";
 import * as moduleCompatibility from "./module-compatibility/index.mjs";
 import * as skills from "./categorized-skill-system/index.mjs";
 
@@ -40,6 +41,12 @@ Hooks.on("init", ()=>{
     tokenDrop.register();
   } catch (e) {
     console.error("tokenDrop.register():", e);
+  }
+
+  try {
+    tokenSize.register();
+  } catch (e) {
+    console.error("tokenSize.register():", e);
   }
 
   try {

--- a/js/module-compatibility/item-piles.mjs
+++ b/js/module-compatibility/item-piles.mjs
@@ -48,7 +48,7 @@ function insertItemHeaderButtons(itemSheet) {
   if (!game.user.isGM) return;
 
   let obj = itemSheet?.object ?? itemSheet?.item;
-  if (!actorSheet.options.window.controls.find(c=>c.action === "configure-item-pile-entry")) {
+  if (!itemSheet.options.window.controls.find(c=>c.action === "configure-item-pile-entry")) {
     itemSheet.options.window.controls.unshift({
       label: game.settings.get("item-piles", "hideActorHeaderText") ? "" : game.i18n.localize("ITEM-PILES.HeaderButtons.Configure"),
       icon: "fas fa-box-open",

--- a/js/settings.mjs
+++ b/js/settings.mjs
@@ -113,6 +113,26 @@ export function register() {
 		hint: "Whether to use a level-up button and pending exp flags",
 	});
 
+	game.settings.register(MODULENAME, "disableSmallHumanoidTokens", {
+		name: "Disable Small Humanoid Tokens",
+		default: true,
+		type: Boolean,
+		scope: "world",
+		requiresReload: true,
+		config: true,
+		hint: "For humanoid tokens, set the minimum automatic size to 1 grid space.",
+	});
+
+	game.settings.register(MODULENAME, "disableSmallPokemonTokens", {
+		name: "Disable Small Pokemon Tokens",
+		default: false,
+		type: Boolean,
+		scope: "world",
+		requiresReload: true,
+		config: true,
+		hint: "For pokemon tokens, set the minimum automatic size to 1 grid space.",
+	});
+
 	if (game.modules.get("item-piles")?.active) {
 		game.settings.register(MODULENAME, "excludeItemPileFromCombat", {
 			name: "Exclude Item Pile From Combat",

--- a/js/token-drop.mjs
+++ b/js/token-drop.mjs
@@ -6,6 +6,13 @@ function OnCreateToken(token) {
   if (!scene) return;
   const combat = game.combats.find(c=>c.scene === scene);
   if (!combat || !combat.active) return;
+
+  if (game.modules.get("item-piles")?.active &&
+      game.settings.get(MODULENAME, "excludeItemPileFromCombat") &&
+      token?.flags?.["item-piles"]?.data?.enabled) {
+    return;
+  }
+
   Dialog.confirm({
     title: `Token Drop - ${token.name}`,
     content: `Add ${token.name} to the active combat?`,

--- a/js/token-size.mjs
+++ b/js/token-size.mjs
@@ -1,0 +1,25 @@
+import { MODULENAME } from "./utils.mjs";
+
+function Token_prepareSize(wrapper, token) {
+  const type = token?.actor?.type;
+  if (!type) return wrapper(token);
+  if (type === "humanoid" && !game.settings.get(MODULENAME, "disableSmallHumanoidTokens")) return wrapper(token);
+  if (type === "pokemon" && !game.settings.get(MODULENAME, "disableSmallPokemonTokens")) return wrapper(token);
+
+  const { width, height } = token;
+  const { scaleX, scaleY } = token.texture;
+  wrapper(token);
+  if (token.flags.ptr2e.linkToActorSize && token.actor) {
+    if (token.width < width) token.width = width;
+    if (token.height < height) token.height = height;
+  }
+  if (game.ptr.settings.tokens.autoscale && token.flags.ptr2e.autoscale) {
+    if (token.texture.scaleX < scaleX) token.texture.scaleX = scaleX;
+    if (token.texture.scaleY < scaleY) token.texture.scaleY = scaleY;
+  }
+}
+
+
+export function register() {
+  libWrapper.register(MODULENAME, "CONFIG.PTR.Token.documentClass.prepareSize", Token_prepareSize, "WRAPPER");
+}

--- a/module.json
+++ b/module.json
@@ -9,7 +9,7 @@
       "url": ""
     }
   ],
-  "version": "0.2.3",
+  "version": "0.2.4",
   "compatibility": {
     "minimum": "12.327",
     "verified": "12.331"
@@ -56,5 +56,5 @@
   },
   "url": "https://github.com/righthandofvecna/ptr2e-modifications",
   "manifest": "https://github.com/righthandofvecna/ptr2e-modifications/releases/latest/download/module.json",
-  "download": "https://github.com/righthandofvecna/ptr2e-modifications/releases/download/v0.2.3/module.zip"
+  "download": "https://github.com/righthandofvecna/ptr2e-modifications/releases/download/v0.2.4/module.zip"
 }


### PR DESCRIPTION
Add ability to disable "tiny" and "diminutive" sizings for tokens en-masse, so they don't use the subgrid unless that is specifically set on the token